### PR TITLE
Add configurable announce interval

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -18,6 +18,7 @@ function SilverDragon:OnInitialize()
 		},
 		notes = true,
 		scan = true,
+		announceInterval = 600,
 		announce = {
 			chat = true,
 			error = true,
@@ -40,23 +41,29 @@ function SilverDragon:OnInitialize()
 							else self:CancelScheduledEvent('SilverDragon_Scan') end
 						end,
 					},
-					announce = {
-						name=L["Announce"], desc=L["Display a message when a rare is detected nearby"],
-						type="group", args={
-							chat = {
-								name=L["Chat"], desc=L["In the chatframe"],
-								type="toggle",
-								get=function() return self.db.profile.announce.chat end,
-								set=function(t) self.db.profile.announce.chat = t end,
-							},
-							error = {
-								name=L["Error"], desc=L["In the errorframe"],
-								type="toggle",
-								get=function() return self.db.profile.announce.error end,
-								set=function(t) self.db.profile.announce.error = t end,
-							},
+				announce = {
+					name=L["Announce"], desc=L["Display a message when a rare is detected nearby"],
+					type="group", args={
+						chat = {
+							name=L["Chat"], desc=L["In the chatframe"],
+							type="toggle",
+							get=function() return self.db.profile.announce.chat end,
+							set=function(t) self.db.profile.announce.chat = t end,
+						},
+						error = {
+							name=L["Error"], desc=L["In the errorframe"],
+							type="toggle",
+							get=function() return self.db.profile.announce.error end,
+							set=function(t) self.db.profile.announce.error = t end,
+						},
+						interval = {
+							name=L["Announce Interval"], desc=L["Time between rare alerts"],
+							type="range", min=60, max=3600, step=60,
+							get=function() return self.db.profile.announceInterval end,
+							set=function(t) self.db.profile.announceInterval = t end,
 						},
 					},
+				},
 					notes = {
 						name=L["Notes"], desc=L["Make notes in Cartographer"],
 						type="toggle",
@@ -191,7 +198,7 @@ function SilverDragon:Announce(name, dead)
 	-- Announce the discovery of a rare.  Return true if we announced.
 	-- Only announce each rare every 10 minutes, preventing spam while we're in combat.
 	-- TODO: Make that time configurable.
-	if (not self.lastseen[name]) or (self.lastseen[name] < (time() - 600)) then
+	if (not self.lastseen[name]) or (self.lastseen[name] < (time() - self.db.profile.announceInterval)) then
 		if self.db.profile.announce.error then
 			UIErrorsFrame:AddMessage(string.format(L["%s seen!"], name), 1, 0, 0, 1, UIERRORS_HOLD_TIME)
 			if dead then

--- a/Locale.enUS.lua
+++ b/Locale.enUS.lua
@@ -13,6 +13,8 @@ L:RegisterTranslations("enUS", function() return {
 	["Scan for nearby rares at a regular interval"] = true,
 	["Announce"] = true,
 	["Display a message when a rare is detected nearby"] = true,
+	["Announce Interval"] = true,
+	["Time between rare alerts"] = true,
 	["Chat"] = true,
 	["In the chatframe"] = true,
 	["Error"] = true,


### PR DESCRIPTION
## Summary
- add a profile default and localization for a configurable rare announcement interval
- expose the interval in the options menu and honor the profile value when throttling announcements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cef78d396c8325901a546699c50ff2